### PR TITLE
remove implicit fill from strokeRect

### DIFF
--- a/canvas/printed/canvas/svgrender.d
+++ b/canvas/printed/canvas/svgrender.d
@@ -102,7 +102,7 @@ public:
 
     override void strokeRect(float x, float y, float width, float height)
     {
-        output(format(`<rect x="%s" y="%s" width="%s" height="%s" stroke="%s"/>`, x, y, width, height, _currentStroke));
+        output(format(`<rect x="%s" y="%s" width="%s" height="%s" stroke="%s" fill="none"/>`, x, y, width, height, _currentStroke));
     }
 
     override TextMetrics measureText(string text)


### PR DESCRIPTION
The fill property defaults to black.
To stroke without filling  it is necessary to specify fill="none".
Possibly this applies to other functions.