### PR TITLE
Make font embedding optional in SVG and HTML

### DIFF
--- a/canvas/printed/canvas/htmlrender.d
+++ b/canvas/printed/canvas/htmlrender.d
@@ -21,9 +21,9 @@ public:
         super(pageWidthMm, pageHeightMm);
     }
 
-    override const(ubyte)[] bytes()
+    override const(ubyte)[] bytes(bool embedFonts = true)
     {
-        auto svgBytes = super.bytes();
+        auto svgBytes = super.bytes(embedFonts);
         auto htmlHeader = cast(const(ubyte)[])( getHTMLHeader() );
         auto htmlFooter = cast(const(ubyte)[])( getHTMLFooter() );
 

--- a/font/printed/font/opentype.d
+++ b/font/printed/font/opentype.d
@@ -174,7 +174,7 @@ public:
             const(ubyte)[] headTable = findTable(0x68656164 /* 'head' */);
             if (headTable !is null)
             {
-                skipBytes(headTable, 4 /*version*/ + 4 /*fontRevision*/ + 4 /*checkSumAdjustment*/ + 4 /*magicNumber*/ 
+                skipBytes(headTable, 4 /*version*/ + 4 /*fontRevision*/ + 4 /*checkSumAdjustment*/ + 4 /*magicNumber*/
                                      + 2 /*flags*/ + 2 /*_unitsPerEm*/ + 16 /*created+modified*/+4*2/*bounding box*/ );
                 ushort macStyle = popBE!ushort(headTable);
 
@@ -231,7 +231,13 @@ public:
                 else
                     _style = OpenTypeFontStyle.normal;
             }
-        }        
+        }
+    }
+
+    /// Returns: a typographics family name suitable for grouping fonts per family in menus
+    string fullFontName()
+    {
+        return getName(NameID.fullFontName);
     }
 
     /// Returns: a typographics family name suitable for grouping fonts per family in menus
@@ -310,7 +316,7 @@ public:
                 float actualUnits = _ascender - _descender;
                 return 0.5f * (_ascender + _descender) * _unitsPerEm / actualUnits;
 
-            case alphabetic: 
+            case alphabetic:
                 return 0; // the default "baseline"
 
             case bottom:
@@ -354,7 +360,7 @@ public:
         return _ascender; // looks like ascent, but perhaps not
     }
 
-    /// Returns: Italic angle in counter-clockwise degrees from the vertical. 
+    /// Returns: Italic angle in counter-clockwise degrees from the vertical.
     /// Zero for upright text, negative for text that leans to the right (forward).
     float postScriptItalicAngle()
     {
@@ -641,7 +647,7 @@ private:
                                 ushort* p = cast(ushort*)(idRangeOffsetArray.ptr);
                                 p = p + seg;
                                 p = p + (ch - startCount[seg]);
-                                p = p + (idRangeOffset[seg]/2);    
+                                p = p + (idRangeOffset[seg]/2);
                                 ubyte[] pslice = cast(ubyte[])(p[0..1]);
                                 glyphIndex = popBE!ushort(pslice);
 
@@ -656,7 +662,7 @@ private:
                             }
                             _charToGlyphMapping[ch] = glyphIndex;
 
-                            if (ch > _maxCodepoint) 
+                            if (ch > _maxCodepoint)
                                 _maxCodepoint = ch;
                         }
                     }


### PR DESCRIPTION
Hi Guillaume,

this is my appraoch to making the embedding of fonts optional in SVG (and consequently HTML). I don't really mind if you include this into the main repo, I just wanted to share it for reference and dicussion.

Maybe there is a better API for this? Since the font should probably be always embedded in PDF, I would keep this feature out of `IRenderingContext2D`. Another approach for a standardized API could be to define a separated interface that renderes MAY implement:

```d
/// Describes an interface for renderers supporting system fonts. These
/// renderers may be instructed to skip font embedding and use the lcoal
/// system fonts instead.
interface SystemFontRenderer
{
    /// Enable/disable font embedding.
    void setFontEmbedding(bool enable);

    /// Get the state of font embedding.
    bool getFontEmbedding();

    /// Subclasses may support providing alternative sources for fonts
    /// that are unavailable on the current system. The `source` must be
    /// provided in the same format as CSS `@font-face` rules. Multiple values
    /// may be provided either by multiple calls to this methods or as a
    /// comma-separated string.
    /// 
    /// See_also: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src
    void addFontSource(string source);
}
```
