### PR TITLE
`stroke()` should not fill in `SVGDocument`

### DIFF
--- a/canvas/printed/canvas/svgrender.d
+++ b/canvas/printed/canvas/svgrender.d
@@ -209,7 +209,7 @@ public:
 
     override void stroke()
     {
-        output(format(`<path d="%s" stroke="%s" stroke-width="%s" stroke-dasharray="%-(%f %)" stroke-dashoffset="%f"/>`, _currentPath, _currentStroke, convertFloatToText(_currentLineWidth), _dashSegments, _dashOffset));
+        output(format(`<path d="%s" fill="none" stroke="%s" stroke-width="%s" stroke-dasharray="%-(%f %)" stroke-dashoffset="%f"/>`, _currentPath, _currentStroke, convertFloatToText(_currentLineWidth), _dashSegments, _dashOffset));
     }
 
     override void fillAndStroke()


### PR DESCRIPTION
- the SVG standard sets a default `fill` of `black` which needs to be explicitly
  unset (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill#path)