### PR TITLE
Added circle and ellipse shapes

### DIFF
--- a/canvas/printed/canvas/irenderer.d
+++ b/canvas/printed/canvas/irenderer.d
@@ -107,6 +107,14 @@ interface IRenderingContext2D
     void fillRect(float x, float y, float width, float height);
     void strokeRect(float x, float y, float width, float height);
 
+    ///
+    void fillCircle(float x, float y, float radius);
+    void strokeCircle(float x, float y, float radius);
+
+    ///
+    void fillEllipse(float x, float y, float rx, float ry);
+    void strokeEllipse(float x, float y, float rx, float ry);
+
     /// Draw filled text.
     void fillText(string text, float x, float y);
 

--- a/canvas/printed/canvas/pdfrender.d
+++ b/canvas/printed/canvas/pdfrender.d
@@ -380,6 +380,101 @@ final class PDFDocument : IRenderingContext2D
         stroke();
     }
 
+    override void fillCircle(float x, float y, float radius)
+    {
+        ellipsePath(x, y, radius, radius);
+        fill();
+    }
+
+    override void strokeCircle(float x, float y, float radius)
+    {
+        setDashPattern();
+        outDelim();
+        ellipsePath(x, y, radius, radius);
+        stroke();
+    }
+
+    override void fillEllipse(float x, float y, float rx, float ry)
+    {
+        ellipsePath(x, y, rx, ry);
+        fill();
+    }
+
+    override void strokeEllipse(float x, float y, float rx, float ry)
+    {
+        setDashPattern();
+        outDelim();
+        ellipsePath(x, y, rx, ry);
+        stroke();
+    }
+
+    private void ellipsePath(float x, float y, float rx, float ry)
+    {
+        // This number is required to construct a circle. It provides the optimal
+        // locations of the Bezier control points.
+        //
+        // https://spencermortensen.com/articles/bezier-circle/
+        enum float c = 4.0/3.0*(sqrt(2.0) - 1);
+        const crx = c*rx;
+        const cry = c*ry;
+
+        // -- top-right arc
+        // start path at top point of circle
+        outFloat(x);
+        outFloat(y - ry);
+        output(" m");
+        // first bezier control point
+        outFloat(x + crx);
+        outFloat(y - ry);
+        // secon bezier control point
+        outFloat(x + rx);
+        outFloat(y - cry);
+        // target at right-most point of circle
+        outFloat(x + rx);
+        outFloat(y);
+        // conclude Bezier segment
+        output(" c");
+
+        // -- bottom-right arc
+        // first bezier control point
+        outFloat(x + rx);
+        outFloat(y + cry);
+        // secon bezier control point
+        outFloat(x + crx);
+        outFloat(y + ry);
+        // target at right-most point of circle
+        outFloat(x);
+        outFloat(y + ry);
+        // conclude Bezier segment
+        output(" c");
+
+        // -- bottom-left arc
+        // first bezier control point
+        outFloat(x - crx);
+        outFloat(y + ry);
+        // secon bezier control point
+        outFloat(x - rx);
+        outFloat(y + cry);
+        // target at right-most point of circle
+        outFloat(x - rx);
+        outFloat(y);
+        // conclude Bezier segment
+        output(" c");
+
+        // -- top-left arc
+        // first bezier control point
+        outFloat(x - rx);
+        outFloat(y - cry);
+        // secon bezier control point
+        outFloat(x - crx);
+        outFloat(y - ry);
+        // target at right-most point of circle
+        outFloat(x);
+        outFloat(y - ry);
+        // conclude Bezier segment
+        output(" c");
+    }
+
     // Path construction
 
     override void beginPath(float x, float y)

--- a/canvas/printed/canvas/svgrender.d
+++ b/canvas/printed/canvas/svgrender.d
@@ -139,6 +139,47 @@ public:
                       _currentStroke, convertFloatToText(_currentLineWidth), _dashSegments, _dashOffset));
     }
 
+    override void fillCircle(float x, float y, float radius)
+    {
+        output(format(`<circle cx="%s" cy="%s" r="%s" fill="%s"/>`,
+                      convertFloatToText(x), convertFloatToText(y), convertFloatToText(radius), _currentFill));
+    }
+
+    override void strokeCircle(float x, float y, float radius)
+    {
+        output(format(
+            `<circle cx="%s" cy="%s" r="%s" stroke="%s" stroke-width="%s" stroke-dasharray="%-(%f %)" stroke-dashoffset="%f" fill="none"/>`,
+            convertFloatToText(x),
+            convertFloatToText(y),
+            convertFloatToText(radius),
+            _currentStroke,
+            convertFloatToText(_currentLineWidth),
+            _dashSegments,
+            _dashOffset
+        ));
+    }
+
+    override void fillEllipse(float x, float y, float rx, float ry)
+    {
+        output(format(`<ellipse cx="%s" cy="%s" rx="%s" ry="%s" fill="%s"/>`,
+                      convertFloatToText(x), convertFloatToText(y), convertFloatToText(rx), convertFloatToText(ry), _currentFill));
+    }
+
+    override void strokeEllipse(float x, float y, float rx, float ry)
+    {
+        output(format(
+            `<ellipse cx="%s" cy="%s" rx="%s" ry="%s" stroke="%s" stroke-width="%s" stroke-dasharray="%-(%f %)" stroke-dashoffset="%f" fill="none"/>`,
+            convertFloatToText(x),
+            convertFloatToText(y),
+            convertFloatToText(rx),
+            convertFloatToText(ry),
+            _currentStroke,
+            convertFloatToText(_currentLineWidth),
+            _dashSegments,
+            _dashOffset
+        ));
+    }
+
     override TextMetrics measureText(string text)
     {
         string svgFamilyName;


### PR DESCRIPTION
I added `circle` and `ellipse` methods to the renderer interface. These are not part of the Canvas 2D context API but I feel they are useful features for many users/use cases.

As far as I can tell, the Canvas 2D context API only specifies `arc` to draw circles and ellipses which seems to be much complicated to handle in both SVG and PDF. At the same time, it is more powerful because it can create arcs (i.e. partial ellipses) and ellipses with non-perpendicular axes.

I am happy to discuss different options of including these type of objects into the interface.